### PR TITLE
fix: load external font stylesheet asynchronously to prevent blocking module scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"></noscript>
 
     <style>
         :root {


### PR DESCRIPTION
This fixes an issue where the app hangs indefinitely on the 'AETHER' loading screen.

The root cause was the synchronous `<link rel="stylesheet">` tag for Google Fonts. If this network request is slow or hangs, the browser blocks the execution of the deferred module script (`src/main.js`). Because the initialization function (`init`) inside `main.js` is responsible for removing the loading screen, the app stays stuck on the loading screen forever.

By changing the font `<link>` to load asynchronously using the `media="print" onload="this.media='all'"` pattern, the stylesheet no longer blocks the deferred script execution or the `DOMContentLoaded` event. A `<noscript>` fallback was also added for accessibility.

Testing:
- Verified locally that the app successfully bypassed the loading screen even when the Google Fonts request is intentionally blocked via playwright interception.
- Ran Vitest suite; all tests passed.

---
*PR created automatically by Jules for task [6420668373786701078](https://jules.google.com/task/6420668373786701078) started by @rajeshceg3*