### PR TITLE
Fix WebGL module specifier resolution by using local WebGL utility

### DIFF
--- a/src/Utils/webgl.js
+++ b/src/Utils/webgl.js
@@ -1,0 +1,32 @@
+export const isWebGLAvailable = () => {
+    try {
+        const canvas = document.createElement('canvas');
+        return !!(
+            window.WebGLRenderingContext &&
+            (canvas.getContext('webgl') || canvas.getContext('experimental-webgl'))
+        );
+    } catch {
+        return false;
+    }
+};
+
+export const getWebGLErrorMessage = () => {
+    const message = window.WebGLRenderingContext
+        ? 'Your graphics card does not seem to support WebGL.'
+        : 'Your browser does not seem to support WebGL.';
+
+    const element = document.createElement('div');
+    element.id = 'webglmessage';
+    element.style.fontFamily = 'monospace';
+    element.style.fontSize = '13px';
+    element.style.fontWeight = 'normal';
+    element.style.textAlign = 'center';
+    element.style.background = '#fff';
+    element.style.color = '#000';
+    element.style.padding = '1.5em';
+    element.style.width = '400px';
+    element.style.margin = '5em auto 0';
+    element.textContent = message;
+
+    return element;
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { SceneManager } from './World/SceneManager.js';
 import { UIManager } from './UI/Interface.js';
 import { resetState } from './State.js';
-import WebGL from 'three/addons/capabilities/WebGL.js';
+import { isWebGLAvailable, getWebGLErrorMessage } from './Utils/webgl.js';
 
 const init = () => {
     console.log("Initializing Aether...");
@@ -11,9 +11,9 @@ const init = () => {
         resetState();
 
         // 1. WebGL Capability Check
-        if (!WebGL.isWebGLAvailable()) {
+        if (!isWebGLAvailable()) {
             console.error("WebGL not available");
-            const warning = WebGL.getWebGLErrorMessage();
+            const warning = getWebGLErrorMessage();
             const loader = document.getElementById('loader');
             if (loader) {
                 loader.innerHTML = ''; // Clear loader


### PR DESCRIPTION
### Motivation
- Runtime environments reported a failed module specifier for `three/addons/capabilities/WebGL.js`, causing WebGL capability checks to break at import time.  
- The intent is to avoid fragile addon import paths by providing an equivalent local capability check so initialization stays robust across bundlers/environments.

### Description
- Replaced `import WebGL from 'three/addons/capabilities/WebGL.js'` in `src/main.js` with `import { isWebGLAvailable, getWebGLErrorMessage } from './Utils/webgl.js'`.  
- Added `src/Utils/webgl.js` which exports `isWebGLAvailable()` and `getWebGLErrorMessage()` that mirror the previous behavior but use a relative local module.  
- Updated the initialization flow in `src/main.js` to call `isWebGLAvailable()` and `getWebGLErrorMessage()` and preserve the same loader fallback UI.

### Testing
- Ran `npm run build` and the production build completed successfully.  
- Ran unit tests with `npm test` and all test suites passed.  
- Ran `npm run lint` and observed pre-existing lint errors unrelated to this change (lint did not pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28563bf408328abc5b92ac641a03d)